### PR TITLE
Configurable time limit

### DIFF
--- a/Classes/KFGG.uc
+++ b/Classes/KFGG.uc
@@ -77,6 +77,10 @@ event InitGame(string Options, out string Error) {
     local KFLevelRules KFLRit;
     local ShopVolume SH;
     local ZombieVolume ZZ;
+    local KFGGSettings Settings;
+
+    Settings = new(outer) class'KFGGSettings';
+    TimeLimit = Settings.TimeLimit;
 
     MaxLives = 0;
     super(DeathMatch).InitGame(Options, Error);

--- a/Classes/KFGG.uc
+++ b/Classes/KFGG.uc
@@ -11,8 +11,7 @@ class KFGG extends KFGameType
     config(KFGunGameGarbage);
 
 var int WarmupTime; // How long to do a pre match warmup before starting the round
-var bool bDidWarmup, bDoingWarmup;
-var int WarmupCountDown;
+var bool bDidWarmup;
 
 var private transient KFGGGameReplicationInfo GG_GRI;
 var private transient array<string> WeaponList;
@@ -459,7 +458,7 @@ function Killed(Controller Killer, Controller Killed, Pawn KilledPawn, class<Dam
             }
         }
 
-        if (!bDoingWarmup && KFGGPRI(Killer.PlayerReplicationInfo).WeaponLevel >= WeaponList.Length) {
+        if (!GG_GRI.bDoingWarmup && KFGGPRI(Killer.PlayerReplicationInfo).WeaponLevel >= WeaponList.Length) {
             MusicPlaying = true;
             CalmMusicPlaying = false;
 
@@ -783,7 +782,7 @@ auto State PendingMatch {
     function beginstate() {
         bWaitingToStartMatch = true;
         StartupStage = 0;
-        WarmupCountDown = WarmupTime;
+        GG_GRI.WarmupCountDown = WarmupTime;
         // if (IsA('xLastManStandingGame') )
         //     NetWait = Max(NetWait,10);
     }
@@ -855,17 +854,17 @@ state MatchInProgress {
         GameReplicationInfo.ElapsedTime = ElapsedTime;
 
         if (!bDidWarmup && WarmupTime > 0) {
-            WarmupCountDown--;
+            GG_GRI.WarmupCountDown--;
 
-            if (WarmupCountDown <= (default.CountDown - 1) && WarmupCountDown > 0) {
-                StartupStage = 5 - WarmupCountDown;
+            if (GG_GRI.WarmupCountDown <= (default.CountDown - 1) && GG_GRI.WarmupCountDown > 0) {
+                StartupStage = 5 - GG_GRI.WarmupCountDown;
                 PlayStartupMessage();
             }
 
-            if (WarmupCountDown <= 0) {
+            if (GG_GRI.WarmupCountDown <= 0) {
                 ResetBeforeMatchStart();
                 bDidWarmup = true;
-                bDoingWarmup = false;
+                GG_GRI.bDoingWarmup = false;
                 StartMatch();
 
                 for (C = Level.ControllerList; C != none; C = C.nextController) {
@@ -885,7 +884,7 @@ state MatchInProgress {
                 StartupStage = 6;
 
             } else {
-                bDoingWarmup = true;
+                GG_GRI.bDoingWarmup = true;
             }
         } else {
             bDidWarmup = true;

--- a/Classes/KFGGGameReplicationInfo.uc
+++ b/Classes/KFGGGameReplicationInfo.uc
@@ -3,11 +3,13 @@ class KFGGGameReplicationInfo extends KFGameReplicationInfo;
 const MAXWEAPONS=100;           // 100 is more than enough for all vanilla weapons + custom gg ones
 var byte MaxWeaponLevel;        // The maximum weapon level before someone wins the match
 var int WarmupTime;             // How long to do a pre match warmup before starting the round
+var int WarmupCountDown;
+var bool bDoingWarmup;
 var string weapons[MAXWEAPONS];
 
 replication {
     reliable if (Role == ROLE_Authority)
-        MaxWeaponLevel, WarmupTime, weapons;
+        MaxWeaponLevel, WarmupTime, weapons, WarmupCountDown, bDoingWarmup;
 }
 
 // load all required stuff from `KFGGSettings`

--- a/Classes/KFGGScoreBoard.uc
+++ b/Classes/KFGGScoreBoard.uc
@@ -9,6 +9,7 @@ var localized string WeaponLevelString;
 function DrawTitle(Canvas Canvas, float HeaderOffsetY, float PlayerAreaY, float PlayerBoxSizeY) {
     local string TitleString, ScoreInfoString, RestartString;
     local float TitleXL, ScoreInfoXL, YL, TitleY, TitleYL;
+    local KFGG GGinfo;
 
     TitleString = GameTypeTitleString @
         "|" @
@@ -21,10 +22,17 @@ function DrawTitle(Canvas Canvas, float HeaderOffsetY, float PlayerAreaY, float 
     Canvas.Font = class'ROHud'.static.GetSmallMenuFont(Canvas);
     Canvas.StrLen(TitleString, TitleXL, TitleYL);
 
-    if (GRI.TimeLimit != 0) {
-        ScoreInfoString = TimeLimit $ FormatTime(GRI.RemainingTime);
-    } else {
-        ScoreInfoString = FooterText @ FormatTime(GRI.ElapsedTime);
+    GGinfo = KFGG(Level.Game);
+    if(GGinfo != none && GGinfo.bDoingWarmup){
+        ScoreInfoString = "WARMUP:" $ FormatTime(GGinfo.WarmupTime - GRI.ElapsedTime);
+    }
+    else
+    {
+        if (GRI.TimeLimit != 0) {
+            ScoreInfoString = TimeLimit $ FormatTime(GRI.RemainingTime);
+        } else {
+            ScoreInfoString = FooterText @ FormatTime(GRI.ElapsedTime);
+        }
     }
 
     Canvas.DrawColor = HUDClass.default.RedColor;

--- a/Classes/KFGGScoreBoard.uc
+++ b/Classes/KFGGScoreBoard.uc
@@ -9,22 +9,22 @@ var localized string WeaponLevelString;
 function DrawTitle(Canvas Canvas, float HeaderOffsetY, float PlayerAreaY, float PlayerBoxSizeY) {
     local string TitleString, ScoreInfoString, RestartString;
     local float TitleXL, ScoreInfoXL, YL, TitleY, TitleYL;
-    local KFGG GGinfo;
+    local KFGGGameReplicationInfo GG_GRI;
 
+    GG_GRI = KFGGGameReplicationInfo(GRI);
     TitleString = GameTypeTitleString @
         "|" @
         MaxWeaponLevelString $
         ":" @
-        KFGGGameReplicationInfo(GRI).MaxWeaponLevel @
+        GG_GRI.MaxWeaponLevel @
         "|" @
         Level.Title;
 
     Canvas.Font = class'ROHud'.static.GetSmallMenuFont(Canvas);
     Canvas.StrLen(TitleString, TitleXL, TitleYL);
 
-    GGinfo = KFGG(Level.Game);
-    if(GGinfo != none && GGinfo.bDoingWarmup){
-        ScoreInfoString = "WARMUP:" $ FormatTime(GGinfo.WarmupTime - GRI.ElapsedTime);
+    if(GG_GRI != none && GG_GRI.bDoingWarmup){
+        ScoreInfoString = "WARMUP:" $ FormatTime(GG_GRI.WarmupTime - GRI.ElapsedTime);
     }
     else
     {

--- a/Classes/KFGGSettings.uc
+++ b/Classes/KFGGSettings.uc
@@ -4,6 +4,7 @@ class KFGGSettings extends Object
 const INI="KFGunGameSettings";
 
 var config int WarmupTime;              // How long to do a pre match warmup before starting the round
+var config int TimeLimit;               // How long should the match be
 var config string WeaponListName;       // what weapon list to use
 var transient array<string> Weapons;    // weapons!
 
@@ -44,5 +45,6 @@ simulated function array<string> GetAllWeaponLists() {
 defaultproperties {
     // defaults in case someone forgets about config
     WarmupTime=30
+    TimeLimit=15
     WeaponListName="Default"
 }

--- a/Configs/KFGunGameSettings.ini
+++ b/Configs/KFGunGameSettings.ini
@@ -2,6 +2,8 @@
 ;= Home repo: https://github.com/InsultingPros/KFGunGame
 ;= how long to do a pre match warmup before starting the round
 WarmupTime=25
+;= how many minutes should the game last (does not include warmup)
+TimeLimit=15
 ;= what weapon list to use
 WeaponListName=Default
 


### PR DESCRIPTION
## 📑 Configurable time limit
Adds an option in the config file to set how many minutes should the game last.
15 minutes is not enough with lots of guns.

Moreover, do not count warmup time in game time and display how much warmup time is missing in the scoreboard before the start of the match.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project.
- [ ] My code requires changes to the documentation.
- [ ] I have updated the documentation, comments as required.
- [x] I've tested my commits, they work and do not send users to oblivion.